### PR TITLE
Added simple animation functionality and preset hotkey

### DIFF
--- a/obs-visca-control.lua
+++ b/obs-visca-control.lua
@@ -43,7 +43,6 @@ local actions = {
     Preset_8 = 16,
     Preset_9 = 17,
     Animate = 18,
-    Slow_Pan_Right = 19,
 }
 
 local action_active = {


### PR DESCRIPTION
I needed some added functionality for my usecase and thought of contributing back in case you think it's useful.
Two main changes:
1. I added the presets 1 through 9 as hotkeys. This way, I am able to easily automate this through external macros (Touch Portal in my case)
2. I added the action "Animate" and the settings of animation direction and speed (no zoom because I don't need so I didn't take the time to make it). This way you can pan the camera over a crowd automatically in a scene and if you switch scenes, this animation is canceled. Also is helpful if used in conjunction with external macros (Touch Portal in my case) to switch camera and use timers to position the PTZ camera to the beginning of the animation and switch back to the PTZ camera when it begins the animation.